### PR TITLE
Update qgpt2_class.py

### DIFF
--- a/use_case_examples/llm/qgpt2_class.py
+++ b/use_case_examples/llm/qgpt2_class.py
@@ -129,7 +129,7 @@ class QuantizedModel:
                 q_x = np.expand_dims(q_x, axis=0)
 
                 if fhe == "simulate":
-                    q_y = self.circuit.simulate
+                    q_y = self.circuit.simulate(q_x)
 
                 elif fhe == "execute":
                     q_y = self.circuit.encrypt_run_decrypt(q_x)


### PR DESCRIPTION
fixed bug in use_cases_examples/llm/qgpt2_class.py demo where simulate where not called properly. it raised error "TypeError: unsupported operand type(s) for /: 'method' and 'int'" because the <bound method Circuit.simulate> was not called properly, the parameter q_x was missing.